### PR TITLE
Added an `overlay_mtu` field to `AgnetNetworkConfig`.

### DIFF
--- a/include/overlay/internal/messages.proto
+++ b/include/overlay/internal/messages.proto
@@ -45,6 +45,12 @@ message AgentNetworkConfig {
   optional bool allocate_subnet = 1 [default = true];
   optional bool mesos_bridge = 2 [default = true];  
   optional bool docker_bridge = 3 [default = true];
+  // The overhead of the VxLAN header is 54 bytes:
+  // Ethernet(18) + IP(20) + udp (8) + VxLAN(8) = 54
+  // Ideally we should be setting the default MTU to 1500 - 54 = 1446,
+  // however to support GCE we are setting the default MTU value to
+  // 1420 bytes.
+  optional uint32 overlay_mtu = 4 [default = 1420];
 }
 
 


### PR DESCRIPTION
While configuring the Mesos and Docker networks we need to configure
the networks to set an MTU for the veth to accommodate the overhead of
the VxLAN headers. The `overlay_mtu` tells the Agent the MTU that the
networks need to be configured with.
