### PR TITLE
Modified the `MasterManagerProcess` to support batch writes to log.

### DIFF
--- a/src/agent/manager.cpp
+++ b/src/agent/manager.cpp
@@ -91,7 +91,7 @@ namespace overlay {
 namespace agent {
 
 constexpr Duration REGISTRATION_RETRY_INTERVAL_MAX = Minutes(10);
-constexpr Duration INITIAL_BACKOFF_PERIOD = Seconds(30);
+constexpr Duration INITIAL_BACKOFF_PERIOD = Seconds(5);
 
 
 static string OVERLAY_HELP()

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char** argv)
   // If `process::initialize()` returns `false`, then it was called before this
   // invocation, meaning the authentication realm for libprocess-level HTTP
   // endpoints was set incorrectly. This should be the first invocation.
-  if (!process::initialize(None(), DEFAULT_HTTP_AUTHENTICATION_REALM)) {
+  if (!process::initialize(None(), READONLY_HTTP_AUTHENTICATION_REALM)) {
     EXIT(EXIT_FAILURE) << "The call to `process::initialize()` in the tests' "
                        << "`main()` was not the function's first invocation";
   }

--- a/src/tests/overlay_tests.cpp
+++ b/src/tests/overlay_tests.cpp
@@ -484,7 +484,7 @@ TEST_F(OverlayTest, checkMasterAgentComm)
 
 // Tests the ability of the `Agent overlay module` to create Mesos CNI
 // networks when `mesos bridge` has been enabled.
-TEST_F(OverlayTest, checkMesosNetwork)
+TEST_F(OverlayTest, ROOT_checkMesosNetwork)
 {
   Try<Owned<cluster::Master>> master = StartMaster();
   ASSERT_SOME(master);
@@ -565,7 +565,7 @@ TEST_F(OverlayTest, checkMesosNetwork)
 
 // Tests the ability of the `Agent overlay module` to create Docker
 // network.
-TEST_F(OverlayTest, checkDockerNetwork)
+TEST_F(OverlayTest, ROOT_checkDockerNetwork)
 {
   Try<Owned<cluster::Master>> master = StartMaster();
   ASSERT_SOME(master);
@@ -630,7 +630,7 @@ TEST_F(OverlayTest, checkDockerNetwork)
 
 // Tests the ability of the `Master overlay module` to recover
 // checkpointed overlay `State`.
-TEST_F(OverlayTest, checkMasterRecovery)
+TEST_F(OverlayTest, ROOT_checkMasterRecovery)
 {
   Try<Owned<cluster::Master>> master = StartMaster();
   ASSERT_SOME(master);
@@ -764,7 +764,7 @@ TEST_F(OverlayTest, checkMasterRecovery)
 
 // Tests the ability of the `Agent overlay module` to recover
 // `AgentInfo` from the master.
-TEST_F(OverlayTest, checkAgentRecovery)
+TEST_F(OverlayTest, ROOT_checkAgentRecovery)
 {
   Try<Owned<cluster::Master>> master = StartMaster();
   ASSERT_SOME(master);

--- a/src/tests/overlay_tests.cpp
+++ b/src/tests/overlay_tests.cpp
@@ -637,11 +637,11 @@ TEST_F(OverlayTest, checkMasterRecovery)
   // Ask overlay Master to use the replicated log by setting
   // `replicated_log_dir`. We are not specifying `zk` configuration so
   // the `quorum` will default to "1".
-  MasterConfig _masterOverlayConfig;
-  _masterOverlayConfig
+  MasterConfig masterOverlayConfig;
+  masterOverlayConfig
     .set_replicated_log_dir("overlay_replicated_log");
 
-  Try<Owned<Anonymous>> masterModule = startOverlayMaster(_masterOverlayConfig);
+  Try<Owned<Anonymous>> masterModule = startOverlayMaster(masterOverlayConfig);
   ASSERT_SOME(masterModule);
 
   // Master `Anonymous` module created successfully. Lets see if we
@@ -671,7 +671,7 @@ TEST_F(OverlayTest, checkMasterRecovery)
   UPID overlayAgent = UPID(master.get()->pid);
   overlayAgent.id = AGENT_MANAGER_PROCESS_ID;
 
-   Future<Response> agentResponse = process::http::get(
+  Future<Response> agentResponse = process::http::get(
       overlayAgent,
       "overlay");
 
@@ -727,7 +727,7 @@ TEST_F(OverlayTest, checkMasterRecovery)
   // Kill the master.
   masterModule->reset();
 
-  masterModule = startOverlayMaster(_masterOverlayConfig);
+  masterModule = startOverlayMaster(masterOverlayConfig);
   ASSERT_SOME(masterModule);
 
   // Re-start the master and wait for the Agent to re-register.
@@ -755,6 +755,114 @@ TEST_F(OverlayTest, checkMasterRecovery)
   EXPECT_EQ(
       masterAgentInfo.SerializeAsString(),
       recoveredMasterAgentInfo.SerializeAsString());
+}
+
+// Tests the ability of the `Agent overlay module` to recover
+// `AgentInfo` from the master.
+TEST_F(OverlayTest, checkAgentRecovery)
+{
+  Try<Owned<cluster::Master>> master = StartMaster();
+  ASSERT_SOME(master);
+
+  LOG(INFO) << "Master PID: " << master.get()->pid;
+
+  // Ask overlay Master to use the replicated log by setting
+  // `replicated_log_dir`. We are not specifying `zk` configuration so
+  // the `quorum` will default to "1".
+  MasterConfig masterOverlayConfig;
+  masterOverlayConfig
+    .set_replicated_log_dir("overlay_replicated_log");
+
+  Try<Owned<Anonymous>> masterModule = startOverlayMaster(masterOverlayConfig);
+  ASSERT_SOME(masterModule);
+
+  // Master `Anonymous` module created successfully. Lets see if we
+  // can hit the `state` endpoint of the Master.
+  UPID overlayMaster = UPID(master.get()->pid);
+  overlayMaster.id = MASTER_MANAGER_PROCESS_ID;
+
+  AgentConfig agentOverlayConfig;
+  agentOverlayConfig.set_master(stringify(overlayMaster.address));
+  // Enable Mesos network.
+  agentOverlayConfig.mutable_network_config()->set_mesos_bridge(true);
+  // Enable Docker network.
+  agentOverlayConfig.mutable_network_config()->set_docker_bridge(true);
+
+  // Setup a future to notify the test that Agent overlay module has
+  // registered.
+  Future<AgentRegisteredMessage> agentRegisteredMessage = 
+    FUTURE_PROTOBUF(AgentRegisteredMessage(), _, _);
+
+  Try<Owned<Anonymous>> agentModule = startOverlayAgent(agentOverlayConfig);
+  ASSERT_SOME(agentModule);
+
+  AWAIT_READY(agentRegisteredMessage);
+
+  // Agent manager has been created. Hit the `overlay` endpoint to
+  // check that module is up and responding.
+  UPID overlayAgent = UPID(master.get()->pid);
+  overlayAgent.id = AGENT_MANAGER_PROCESS_ID;
+
+  Future<Response> agentResponse = process::http::get(
+      overlayAgent,
+      "overlay");
+
+  AWAIT_EXPECT_RESPONSE_STATUS_EQ(OK().status, agentResponse);
+  AWAIT_EXPECT_RESPONSE_HEADER_EQ(
+      APPLICATION_JSON,
+      "Content-Type",
+      agentResponse);
+
+  // The `overlay` end-point is backed by the
+  // mesos::modules::overlay::AgentInfo protobuf, so need to parse the
+  // JSON and verify that the correct configuration is being
+  // reflected.
+  Try<AgentInfo> info = parseAgentOverlay(agentResponse->body);
+  ASSERT_SOME(info);
+
+  // There should be only 1 overlay.
+  ASSERT_EQ(1, info->overlays_size());
+  EXPECT_EQ(OVERLAY_NAME, info->overlays(0).info().name());
+  
+  Try<net::IPNetwork> agentNetwork = net::IPNetwork::parse(
+      info->overlays(0).subnet(), AF_INET);
+  ASSERT_SOME(agentNetwork);
+  EXPECT_EQ(24, agentNetwork->prefix());
+  
+  Try<net::IPNetwork> allocatedSubnet = net::IPNetwork::parse(
+      "192.168.0.0/24", AF_INET); 
+  ASSERT_SOME(allocatedSubnet);
+  EXPECT_EQ(allocatedSubnet.get(), agentNetwork.get());
+
+  // Re-start the agent and wait for the Agent to re-register.
+  Future<AgentRegisteredMessage> agentReRegisteredMessage = 
+    FUTURE_PROTOBUF(AgentRegisteredMessage(), _, _);
+
+  // Kill the agent.
+  agentModule->reset();
+
+  // re-start the agent.
+  agentModule = startOverlayAgent(agentOverlayConfig);
+  ASSERT_SOME(agentModule);
+
+  AWAIT_READY(agentReRegisteredMessage);
+  // Hit the master end-point again.
+  agentResponse = process::http::get(
+      overlayAgent,
+      "overlay");
+
+  AWAIT_EXPECT_RESPONSE_STATUS_EQ(OK().status, agentResponse);
+  AWAIT_EXPECT_RESPONSE_HEADER_EQ(
+      APPLICATION_JSON,
+      "Content-Type",
+      agentResponse);
+
+  Try<AgentInfo> reRegisterInfo = parseAgentOverlay(agentResponse->body);
+  ASSERT_SOME(reRegisterInfo);
+
+  EXPECT_EQ(
+      info.get().SerializeAsString(),
+      reRegisterInfo.get().SerializeAsString());
 }
 
 } // namespace tests {


### PR DESCRIPTION
Currently, for each agent registration we issue a write to the overlay
replicated log. This can degrade performance of the replicated log
when the number of agents is large. We have therefore introduced batch
writes to the overlay replicated log.

When an agent registers, if there are no pending writes to the
replicated log, the `Operation` used to mutate the `networkState` with
the new `AgentInfo` associated with the agent will be added to the
`operations` queue. The `MasterManagerProcess` will then update the
replicated log with a copy of the updated `networkState`. Once the
replicated log has been successfully updated, the `State` will be
reflected in the `networkState` and a configuration update is sent to
every agent on the list.

As part of these changes have also modified the variables used to
store the state information during "recovery" of the replicated log.
