### PR TITLE
Modified  overlay modules to learn ZK URL from environment variables.

### DIFF
--- a/include/overlay/internal/messages.proto
+++ b/include/overlay/internal/messages.proto
@@ -56,7 +56,7 @@ message AgentNetworkConfig {
 
 // Used by Agent to store the configuration specified by the operator.
 message AgentConfig {
-  required string master = 1;
+  optional string master = 1;
   required string cni_dir = 2;
   optional AgentNetworkConfig network_config = 3;
 }
@@ -65,8 +65,8 @@ message AgentConfig {
 // Used by the Master to determine the zookeeper config required for
 // leader election by the replicated log.
 message ZookeeperConfig {
-  required string url = 1;
-  required uint32 quorum = 2;
+  optional string url = 1;
+  optional uint32 quorum = 2;
   optional uint32 session_timeout = 3 [default = 10];
 }
 

--- a/include/overlay/overlay.hpp
+++ b/include/overlay/overlay.hpp
@@ -14,6 +14,9 @@ namespace overlay {
 
 
 constexpr char MESOS_BRIDGE_PREFIX[] = "m-";
+constexpr char MESOS_MASTER[] = "MESOS_MASTER";
+constexpr char MESOS_QUORUM[] = "MESOS_QUORUM";
+constexpr char MESOS_ZK[] = "MESOS_ZK";
 constexpr char DOCKER_BRIDGE_PREFIX[] = "d-";
 constexpr char MASTER_MANAGER_PROCESS_ID[] = "overlay-master";
 constexpr char AGENT_MANAGER_PROCESS_ID[] = "overlay-agent";


### PR DESCRIPTION
The ZK URL for master and agent are usually specified as environment
variables. Have modified the overlay modules to learn these parameters
by reading the environment variables rather than learning them
explicitly from their module JSON configuration. This avoids any
duplication required, on part of the operator, to configure these
strings multiple times (one for the master/agent and one for the
modules).
