### PR TITLE
Fixing overlay network configuration failure.

### DIFF
--- a/include/overlay/internal/messages.proto
+++ b/include/overlay/internal/messages.proto
@@ -59,6 +59,9 @@ message AgentConfig {
   optional string master = 1;
   required string cni_dir = 2;
   optional AgentNetworkConfig network_config = 3;
+  // Number of times the agent will attempt to configure virtual
+  // networks by re-registering with the master.
+  optional uint32 max_configuration_attempts = 4 [default = 4];
 }
 
 

--- a/include/overlay/internal/utils.hpp
+++ b/include/overlay/internal/utils.hpp
@@ -38,20 +38,20 @@ inline process::Future<std::string> runScriptCommand(
           process::Future<std::string>>& t) -> process::Future<std::string> {
         process::Future<Option<int>> status = std::get<0>(t);
         if (!status.isReady()) {
-        return process::Failure(
-          "Failed to get the exit status of '" + command +"': " +
-          (status.isFailed() ? status.failure() : "discarded"));
+          return process::Failure(
+            "Failed to get the exit status of '" + command +"': " +
+            (status.isFailed() ? status.failure() : "discarded"));
         }
 
         if (status->isNone()) {
-        return process::Failure("Failed to reap the subprocess");
+          return process::Failure("Failed to reap the subprocess");
         }
 
         process::Future<std::string> out = std::get<1>(t);
         if (!out.isReady()) {
-        return process::Failure(
-          "Failed to read stderr from the subprocess: " +
-          (out.isFailed() ? out.failure() : "discarded"));
+          return process::Failure(
+            "Failed to read stderr from the subprocess: " +
+            (out.isFailed() ? out.failure() : "discarded"));
         }
 
         process::Future<std::string> err = std::get<2>(t);

--- a/include/overlay/overlay.proto
+++ b/include/overlay/overlay.proto
@@ -64,6 +64,7 @@ message AgentOverlayInfo {
       STATUS_INVALID = 0;
       STATUS_OK = 1;
       STATUS_FAILED = 2;
+      STATUS_CONFIGURING = 3;
     }
 
     optional Status status = 1 [default = STATUS_INVALID];

--- a/src/agent/manager.cpp
+++ b/src/agent/manager.cpp
@@ -201,9 +201,8 @@ protected:
     LOG(INFO) << "Overlay master " << pid << " has exited";
 
     if (overlayMaster.isSome() && overlayMaster.get() == pid) {
-      LOG(WARNING)
-        << "Overlay master disconnected! "
-        << "Waiting for a new overlay master to be detected";
+      LOG(WARNING) << "Overlay master disconnected! "
+                   << "Waiting for a new overlay master to be detected";
     }
     
     LOG(INFO) << "Moving " << pid << " to `REGISTERING` state.";
@@ -241,12 +240,11 @@ protected:
 
         if ((status == OverlayState::STATUS_OK) ||
             (status == OverlayState::STATUS_CONFIGURING)) {
-          LOG(INFO)
-            << "Skipping configuration for overlay network '"
-            << name << "' as it "
-            << ((status == OverlayState::STATUS_OK) ?
-                "has been " : "is being ")
-            <<"configured.";
+          LOG(INFO) << "Skipping configuration for overlay network '"
+                    << name << "' as it "
+                    << ((status == OverlayState::STATUS_OK) ?
+                       "has been " : "is being ")
+                    << "configured.";
 
           if (status == OverlayState::STATUS_OK) { 
             // We still set a `Future` for this overlay, so as to inform
@@ -270,9 +268,8 @@ protected:
     // should therefore not setup a response for acknowledging this
     // registration.
     if (futures.empty()) {
-      LOG(INFO)
-        << "Looks like we received a duplicate config update from "
-        << from << " dropping this message.";
+      LOG(INFO) << "Looks like we received a duplicate config update from "
+                << from << " dropping this message.";
       return;
     }
 
@@ -287,9 +284,8 @@ protected:
       const Future<list<Future<Nothing>>>& results)
   {
     if (!results.isReady()) {
-      LOG(ERROR)
-        << "Unable to configure any overlay: "
-        << (results.isDiscarded() ? "discarded" : results.failure());
+      LOG(ERROR) << "Unable to configure any overlay: "
+                 << (results.isDiscarded() ? "discarded" : results.failure());
 
       return;
     }
@@ -305,9 +301,8 @@ protected:
     }
 
     if (!messages.empty()){
-      LOG(ERROR)
-        << "Unable to configure some of the overlays on this Agent: "
-        << strings::join("\n", messages);
+      LOG(ERROR) << "Unable to configure some of the overlays on this Agent: "
+                 << strings::join("\n", messages);
     }
 
     if (state != REGISTERING) {
@@ -361,9 +356,9 @@ protected:
       if (!overlay.has_state() ||
           !overlay.state().has_status() ||
           overlay.state().status() != OverlayState::STATUS_OK) {
-        LOG(ERROR)
-          << "Overlay " << overlay.info().name() << " has not been "
-          << "configured hence dropping register acknowledgment from master.";
+        LOG(ERROR) << "Overlay " << overlay.info().name() << " has not been "
+                   << "configured hence dropping register "
+                   << "acknowledgment from master.";
         return; 
       }
     }


### PR DESCRIPTION
- Added a new state: `STATUS_CONFIGURING` to identify when an overlay network is in the middle of a configuration.
- Modified continuation `__configure` to capture and failures in `iptables` provisioning.
- Modified the handling of register acknowledgement from the master. The agent will now drop any register acknowledgment requests if there is a failure to configure any of the overlay network. This would force the agent to re-register with the master, triggering a re-configuration of the overlay network. Also, added a max number of mis-configurations that the agent module can tolerate before bailing out.
