### PR TITLE
Fixed a compilation error in the overlay module.

### DIFF
--- a/src/agent/manager.cpp
+++ b/src/agent/manager.cpp
@@ -61,7 +61,6 @@ using process::DESCRIPTION;
 using process::Future;
 using process::Failure;
 using process::HELP;
-using process::NO_SETSID;
 using process::Owned;
 using process::Promise;
 using process::Subprocess;


### PR DESCRIPTION
The namespace `process::NO_SETSID` no longer exists in new Mesos releases, this is causing the overlay module to fail compilation with new versions of Mesos. We were anyway not using this namespace, hence removing it to be compatible with Mesos changes. This change is backward compatible.
