### PR TITLE
Add metrics prefix to the replicated log.

### DIFF
--- a/src/master/manager.cpp
+++ b/src/master/manager.cpp
@@ -702,7 +702,8 @@ public:
             Seconds(masterConfig.zk().session_timeout()),
             path::join(url.get().path, REPLICATED_LOG_STORE_REPLICAS),
             url.get().authentication,
-            true);
+            true,
+            "overlay/");
       } else {
         // Use replicated log without ZooKeeper.
         LOG(INFO)
@@ -714,7 +715,8 @@ public:
               masterConfig.replicated_log_dir(),
               REPLICATED_LOG_STORE),
             set<UPID>(),
-            true);
+            true,
+            "overlay/");
       }
 
       storage = new LogStorage(log);


### PR DESCRIPTION
With this change, the overlay module's replicated log will emit a metric:
`overlay/log/recovered`

A value of `1` indicates the module's replicated log has recovered.
